### PR TITLE
Update TelemetryProcessor.php

### DIFF
--- a/src/Monolog/TelemetryProcessor.php
+++ b/src/Monolog/TelemetryProcessor.php
@@ -7,12 +7,13 @@ namespace Spiral\Telemetry\Monolog;
 use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 use Psr\Container\ContainerInterface;
+use Spiral\Core\Attribute\Proxy;
 use Spiral\Telemetry\TracerInterface;
 
 final class TelemetryProcessor implements ProcessorInterface
 {
     public function __construct(
-        private readonly ContainerInterface $container,
+        #[Proxy] private readonly ContainerInterface $container,
     ) {}
 
     /**


### PR DESCRIPTION
This fixes a bug where tracer is not using scoped proxy container, so the trace context is always empty.

Without this fix, telemetry info were never actually added as extra to log records.